### PR TITLE
Add service account scopes and realm frontendUrl

### DIFF
--- a/terraform/clients/solver-director/client.tf
+++ b/terraform/clients/solver-director/client.tf
@@ -12,3 +12,13 @@ resource "keycloak_openid_client" "client" {
   direct_access_grants_enabled = false
   full_scope_allowed           = false
 }
+
+resource "keycloak_openid_client_optional_scopes" "service_account_scopes" {
+  realm_id  = var.realm_id
+  client_id = local.client.id
+
+  optional_scopes = [
+    module.scopes.scopes.solvers_read.name,
+    module.scopes.scopes.problems_read.name,
+  ]
+}

--- a/terraform/realm.tf
+++ b/terraform/realm.tf
@@ -3,6 +3,10 @@ resource "keycloak_realm" "psp" {
   realm        = "psp"
   enabled      = true
   display_name = "Portfolio Solver Platform"
+
+  attributes = {
+    "frontendUrl" = "http://keycloak.local"
+  }
 }
 
 # Explicitly set optional scopes (so we don't just use the default ones)

--- a/terraform/realm.tf
+++ b/terraform/realm.tf
@@ -3,10 +3,6 @@ resource "keycloak_realm" "psp" {
   realm        = "psp"
   enabled      = true
   display_name = "Portfolio Solver Platform"
-
-  attributes = {
-    "frontendUrl" = "http://keycloak.local"
-  }
 }
 
 # Explicitly set optional scopes (so we don't just use the default ones)

--- a/terraform/realm.tf
+++ b/terraform/realm.tf
@@ -3,6 +3,10 @@ resource "keycloak_realm" "psp" {
   realm        = "psp"
   enabled      = true
   display_name = "Portfolio Solver Platform"
+
+  attributes = {
+    "frontendUrl" = "http://${var.keycloak_hostname}"
+  }
 }
 
 # Explicitly set optional scopes (so we don't just use the default ones)

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -15,6 +15,12 @@ variable "keycloak_url" {
   default     = "http://keycloak.local"
 }
 
+variable "keycloak_hostname" {
+  description = "Public hostname for Keycloak (used as frontendUrl in the realm)"
+  type        = string
+  default     = "keycloak.local"
+}
+
 variable "bootstrap_service_client_id" {
   description = "The ID of the bootstrap service client"
   type        = string


### PR DESCRIPTION
## Summary
- Enable optional scopes for solver-director client (solvers:read, problems:read)
- Set realm frontendUrl from `keycloak_hostname` variable to fix JWT issuer mismatch